### PR TITLE
Add MarkdownLint workflow

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,15 @@
+name: MarkdownLint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npx markdownlint-cli '**/*.md'


### PR DESCRIPTION
## Summary
- add workflow to lint Markdown using Node 20

## Testing
- `npx markdownlint-cli '**/*.md'` *(fails: unable to access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_6857db01561483208c86d3a67f40b66b